### PR TITLE
Handle missing post descriptions and add contributor guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Contributor Guidelines for This Repo
+
+Welcome! This document outlines how to work in this project and should be followed for any change in the repository.
+
+## Project Overview
+- **Framework**: [Astro](https://astro.build/) with TypeScript and TailwindCSS.
+- **Content**: Blog posts and other content live in `src/content` using Astro content collections.
+- **UI Components**: Reusable pieces are under `src/components` and `src/layouts`.
+- **Pages**: Route files are in `src/pages`; dynamic routes follow Astro's `[param].astro` convention.
+- **Styling**: Tailwind utilities are preferred. Global styles and typography are configured via `tailwind.config.mjs` and `src/styles`.
+
+## Development Workflow
+- Install dependencies with `npm install`.
+- Run the site locally with `npm run dev`.
+- Build for production (and run the main check) with `npm run build`.
+- When applicable, use `npm run preview` to serve the production build locally.
+
+## Code Conventions
+- Favor existing component patterns before introducing new ones.
+- Keep imports tidy; unused imports should be removed. Never wrap imports in try/catch blocks.
+- Prefer Tailwind utility classes for spacing, color, and typography. If you add new global styles, place them with the existing stylesheets.
+- For content-driven pages, gracefully handle missing optional fields (e.g., draft flags, descriptions) to avoid empty UI elements.
+
+## Testing & Verification
+- At minimum, run `npm run build` before committing. Add any other checks relevant to your changes.
+- Note all executed commands in your final summary.
+
+## Documentation
+- Update README or relevant docs only when your changes alter setup, workflows, or usage.
+- Keep this guide up to date if repository conventions change.
+
+Thanks for contributing! Following these guidelines helps keep the project consistent and easy to maintain.

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -38,17 +38,23 @@ const post = posts.find((post) => post.slug === slug);
 
 if (!post) return Astro.redirect("/404");
 const { Content, headings } = await post.render();
+const description = post.data.description?.trim();
 ---
 
-<Layout title={post.data.title} description={post.data.description}>
+<Layout title={post.data.title} description={description}>
   <Container>
     <div class="animate">
       <BackToPrevious href="/blog">Back to blog</BackToPrevious>
     </div>
-    <div class="my-10 space-y-1">
+    <div class="my-10 space-y-3">
       <h1 class="animate text-3xl font-semibold text-black dark:text-white">
         {post.data.title}
       </h1>
+      {description && (
+        <p class="animate text-base text-black/70 dark:text-white/70">
+          {description}
+        </p>
+      )}
     </div>
     {headings.length > 0 && <TableOfContents headings={headings} />}
     <article class="animate">


### PR DESCRIPTION
## Summary
- trim and conditionally render blog post descriptions on individual post pages
- pass the sanitized description to the page metadata
- add a root AGENTS guide explaining repository structure, conventions, and workflows

## Testing
- npm run build *(fails: astro not installed due to dependency install issues)*
- npm install *(fails: 403 retrieving onnxruntime-node from npm registry)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69200e5827408320925f5f65b74b60d4)