### PR TITLE
Use compile image service for Cloudflare builds

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,7 +13,7 @@ export default defineConfig({
   site: "https://dch.xyz",
   integrations: [sitemap(), mdx(), icon(), react()],
   image: {
-    service: { entrypoint: "astro/assets/services/noop" },
+    service: { entrypoint: "astro/assets/services/compile" },
   },
   markdown: {
     // 1. Enable syntax highlighting with Shiki


### PR DESCRIPTION
### Motivation
- Enable Astro's image compilation at build time for Cloudflare to improve image handling and performance.
- Replace the no-op image service with the compile entrypoint so image assets are processed during the build.

### Description
- Update `astro.config.mjs` to set `image.service.entrypoint` to `astro/assets/services/compile` instead of `astro/assets/services/noop`.
- This change targets Cloudflare build-time optimization and does not alter other integrations.

### Testing
- Ran `npm run build`, which failed with `astro: not found` indicating the local environment is missing the `astro` binary.
- No other automated tests were executed after this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694da03392bc8320bc6ab76c7c4a465b)