### PR TITLE
Add PDF upload + automatic summarization using pdfjs-dist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "astro": "^5.15.9",
         "astro-icon": "^1.1.0",
         "clsx": "^2.1.1",
+        "pdfjs-dist": "^4.3.136",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "rehype-external-links": "^3.0.0",
@@ -3483,6 +3484,256 @@
       },
       "peerDependencies": {
         "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.86",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.86.tgz",
+      "integrity": "sha512-hOkywnrkdFdVpsuaNsZWfEY7kc96eROV2DuMTTvGF15AZfwobzdG2w0eDlU5UBx3Lg/XlWUnqVT5zLUWyo5h6A==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.86",
+        "@napi-rs/canvas-darwin-arm64": "0.1.86",
+        "@napi-rs/canvas-darwin-x64": "0.1.86",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.86",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.86",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.86",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.86",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.86",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.86",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.86",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.86"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.86",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.86.tgz",
+      "integrity": "sha512-IjkZFKUr6GzMzzrawJaN3v+yY3Fvpa71e0DcbePfxWelFKnESIir+XUcdAbim29JOd0JE0/hQJdfUCb5t/Fjrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.86",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.86.tgz",
+      "integrity": "sha512-PUCxDq0wSSJbtaOqoKj3+t5tyDbtxWumziOTykdn3T839hu6koMaBFpGk9lXpsGaPNgyFpPqjxhtsPljBGnDHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.86",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.86.tgz",
+      "integrity": "sha512-rlCFLv4Rrg45qFZq7mysrKnsUbMhwdNg3YPuVfo9u4RkOqm7ooAJvdyDFxiqfSsJJTqupYqa9VQCUt8WKxKhNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.86",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.86.tgz",
+      "integrity": "sha512-6xWwyMc9BlDBt+9XHN/GzUo3MozHta/2fxQHMb80x0K2zpZuAdDKUYHmYzx9dFWDY3SbPYnx6iRlQl6wxnwS1w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.86",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.86.tgz",
+      "integrity": "sha512-r2OX3w50xHxrToTovOSQWwkVfSq752CUzH9dzlVXyr8UDKFV8dMjfa9hePXvAJhN3NBp4TkHcGx15QCdaCIwnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.86",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.86.tgz",
+      "integrity": "sha512-jbXuh8zVFUPw6a9SGpgc6EC+fRbGGyP1NFfeQiVqGLs6bN93ROtPLPL6MH9Bp6yt0CXUFallk2vgKdWDbmW+bw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.86",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.86.tgz",
+      "integrity": "sha512-9IwHR2qbq2HceM9fgwyL7x37Jy3ptt1uxvikQEuWR0FisIx9QEdt7F3huljCky76aoouF2vSd0R2fHo3ESRoPw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.86",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.86.tgz",
+      "integrity": "sha512-Jor+rhRN6ubix+D2QkNn9XlPPVAYl+2qFrkZ4oZN9UgtqIUZ+n+HljxhlkkDFRaX1mlxXOXPQjxaZg17zDSFcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.86",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.86.tgz",
+      "integrity": "sha512-A28VTy91DbclopSGZ2tIon3p8hcVI1JhnNpDpJ5N9rYlUnVz1WQo4waEMh+FICTZF07O3coxBNZc4Vu4doFw7A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.86",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.86.tgz",
+      "integrity": "sha512-q6G1YXUt3gBCAS2bcDMCaBL4y20di8eVVBi1XhjUqZSVyZZxxwIuRQHy31NlPJUCMiyNiMuc6zeI0uqgkWwAmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.86",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.86.tgz",
+      "integrity": "sha512-X0g46uRVgnvCM1cOjRXAOSFSG63ktUFIf/TIfbKCUc7QpmYUcHmSP9iR6DGOYfk+SggLsXoJCIhPTotYeZEAmg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -10129,6 +10380,18 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "4.10.38",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
+      "integrity": "sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.65"
+      }
     },
     "node_modules/pend": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "astro": "^5.15.9",
     "astro-icon": "^1.1.0",
     "clsx": "^2.1.1",
+    "pdfjs-dist": "^4.3.136",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "rehype-external-links": "^3.0.0",

--- a/src/content/projects/local-inference/LocalInference.tsx
+++ b/src/content/projects/local-inference/LocalInference.tsx
@@ -1,6 +1,5 @@
 import { CreateMLCEngine, MLCEngine } from "@mlc-ai/web-llm";
-import { GlobalWorkerOptions, getDocument } from "pdfjs-dist";
-import pdfjsWorker from "pdfjs-dist/build/pdf.worker.min.mjs?url";
+import { GlobalWorkerOptions, getDocument, version } from "pdfjs-dist";
 import { useCallback, useEffect, useState } from "react";
 
 interface ProgressUpdate {
@@ -16,7 +15,9 @@ const MAX_PDF_CHARS = MAX_PDF_TOKENS * APPROX_CHARS_PER_TOKEN;
 const SUMMARY_PROMPT =
   "Summarize the following PDF content in a concise paragraph.";
 
-GlobalWorkerOptions.workerSrc = pdfjsWorker;
+// PDF.js requires a web worker to parse PDFs (runs in separate thread to avoid blocking UI)
+// This must be set before calling getDocument()
+GlobalWorkerOptions.workerSrc = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${version}/pdf.worker.min.mjs`;
 
 export default function LocalInference() {
   const [isInferencing, setIsInferencing] = useState(false);

--- a/src/content/projects/local-inference/LocalInference.tsx
+++ b/src/content/projects/local-inference/LocalInference.tsx
@@ -1,4 +1,6 @@
 import { CreateMLCEngine, MLCEngine } from "@mlc-ai/web-llm";
+import { GlobalWorkerOptions, getDocument } from "pdfjs-dist";
+import pdfjsWorker from "pdfjs-dist/build/pdf.worker.min.js?url";
 import { useCallback, useEffect, useState } from "react";
 
 interface ProgressUpdate {
@@ -8,6 +10,13 @@ interface ProgressUpdate {
 }
 
 const MODEL_ID = "Qwen2.5-0.5B-Instruct-q4f16_1-MLC";
+const MAX_PDF_TOKENS = 10000;
+const APPROX_CHARS_PER_TOKEN = 4;
+const MAX_PDF_CHARS = MAX_PDF_TOKENS * APPROX_CHARS_PER_TOKEN;
+const SUMMARY_PROMPT =
+  "Summarize the following PDF content in a concise paragraph.";
+
+GlobalWorkerOptions.workerSrc = pdfjsWorker;
 
 export default function LocalInference() {
   const [isInferencing, setIsInferencing] = useState(false);
@@ -17,6 +26,18 @@ export default function LocalInference() {
   const [initProgress, setInitProgress] = useState<ProgressUpdate | null>(null);
 
   const [userInput, setUserInput] = useState<string>("What color is the sun?");
+  const [pdfText, setPdfText] = useState<string>("");
+  const [pdfName, setPdfName] = useState<string | null>(null);
+  const [pdfStatus, setPdfStatus] = useState<
+    "idle" | "loading" | "ready" | "error"
+  >("idle");
+  const [pdfError, setPdfError] = useState<string | null>(null);
+  const [pdfTokenCount, setPdfTokenCount] = useState<number>(0);
+  const [isPdfTruncated, setIsPdfTruncated] = useState<boolean>(false);
+  const [pdfSummary, setPdfSummary] = useState<string>("");
+  const [pdfSummaryError, setPdfSummaryError] = useState<string | null>(null);
+  const [isSummarizing, setIsSummarizing] = useState<boolean>(false);
+  const [pendingSummary, setPendingSummary] = useState<boolean>(false);
 
   useEffect(() => {
     if (engine) return;
@@ -40,8 +61,100 @@ export default function LocalInference() {
     initEngine();
   }, []);
 
+  const handlePdfUpload = useCallback(async (file: File | null) => {
+    if (!file) return;
+
+    setPdfStatus("loading");
+    setPdfError(null);
+    setPdfName(file.name);
+    setPdfText("");
+    setPdfTokenCount(0);
+    setIsPdfTruncated(false);
+    setPdfSummary("");
+    setPdfSummaryError(null);
+    setPendingSummary(false);
+
+    try {
+      const arrayBuffer = await file.arrayBuffer();
+      const pdf = await getDocument({ data: arrayBuffer }).promise;
+      let extractedText = "";
+      let truncated = false;
+
+      for (let pageIndex = 1; pageIndex <= pdf.numPages; pageIndex += 1) {
+        const page = await pdf.getPage(pageIndex);
+        const textContent = await page.getTextContent();
+        const items = textContent.items as Array<{ str?: string }>;
+        const pageText = items
+          .map((item) => item.str ?? "")
+          .join(" ")
+          .trim();
+        if (pageText) {
+          extractedText += `${pageText}\n\n`;
+        }
+
+        if (extractedText.length >= MAX_PDF_CHARS) {
+          extractedText = extractedText.slice(0, MAX_PDF_CHARS);
+          truncated = true;
+          break;
+        }
+      }
+
+      const trimmedText = extractedText.trim();
+      if (!trimmedText) {
+        setPdfStatus("error");
+        setPdfError("No text could be extracted from this PDF.");
+        return;
+      }
+
+      const approxTokens = Math.ceil(trimmedText.length / APPROX_CHARS_PER_TOKEN);
+      setPdfText(trimmedText);
+      setPdfTokenCount(approxTokens);
+      setIsPdfTruncated(truncated);
+      setPdfStatus("ready");
+      setPendingSummary(true);
+    } catch (error) {
+      console.error("Failed to read PDF:", error);
+      setPdfStatus("error");
+      setPdfError("Could not read this PDF. Please try a different file.");
+    }
+  }, []);
+
+  useEffect(() => {
+    if (
+      !engine ||
+      !pendingSummary ||
+      !pdfText ||
+      isInferencing ||
+      isSummarizing
+    ) {
+      return;
+    }
+
+    const summarizePdf = async () => {
+      setIsSummarizing(true);
+      setPdfSummaryError(null);
+      try {
+        const prompt = `${SUMMARY_PROMPT}\n\n${pdfText}`;
+        const messages = [
+          { role: "system" as const, content: "You are a helpful AI assistant." },
+          { role: "user" as const, content: prompt },
+        ];
+        const reply = await engine.chat.completions.create({ messages });
+        setPdfSummary(reply.choices[0].message.content);
+      } catch (error) {
+        console.error("PDF summary failed:", error);
+        setPdfSummaryError("Failed to summarize this PDF.");
+      } finally {
+        setIsSummarizing(false);
+        setPendingSummary(false);
+      }
+    };
+
+    void summarizePdf();
+  }, [engine, isInferencing, isSummarizing, pdfText, pendingSummary]);
+
   const runInference = useCallback(async () => {
-    if (!engine || isInferencing) return;
+    if (!engine || isInferencing || isSummarizing) return;
 
     setIsInferencing(true);
     try {
@@ -65,7 +178,7 @@ export default function LocalInference() {
     } finally {
       setIsInferencing(false);
     }
-  }, [engine, userInput]);
+  }, [engine, isInferencing, isSummarizing, userInput]);
 
   return (
     <div className="flex flex-col items-center gap-4">
@@ -80,13 +193,13 @@ export default function LocalInference() {
             className="w-full rounded border border-black/15 bg-white p-2 text-black dark:border-white/20 dark:bg-neutral-800 dark:text-white"
             rows={4}
             placeholder="Enter your message here..."
-            disabled={isModelLoading || isInferencing}
+            disabled={isModelLoading || isInferencing || isSummarizing}
           />
           <button
             onClick={runInference}
-            disabled={isModelLoading || isInferencing || !engine}
+            disabled={isModelLoading || isInferencing || isSummarizing || !engine}
             className={`mt-2 rounded bg-blue-500 px-4 py-2 text-white transition-colors ${
-              isModelLoading || isInferencing || !engine
+              isModelLoading || isInferencing || isSummarizing || !engine
                 ? "cursor-not-allowed opacity-50"
                 : "hover:bg-blue-600"
             }`}
@@ -126,6 +239,57 @@ export default function LocalInference() {
             )}
           </>
         )}
+
+        <div className="mt-6 border-t border-black/10 pt-4 dark:border-white/10">
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-semibold text-black dark:text-white">
+              Upload a PDF to summarize
+            </label>
+            <input
+              type="file"
+              accept="application/pdf"
+              className="w-full rounded border border-black/15 bg-white p-2 text-sm text-black dark:border-white/20 dark:bg-neutral-800 dark:text-white"
+              disabled={
+                isModelLoading || isSummarizing || pdfStatus === "loading"
+              }
+              onChange={(event) =>
+                void handlePdfUpload(event.target.files?.[0] ?? null)
+              }
+            />
+            {pdfStatus === "loading" && (
+              <div className="text-sm text-black/60 dark:text-white/60">
+                Reading PDF content...
+              </div>
+            )}
+            {pdfStatus === "error" && pdfError && (
+              <div className="text-sm text-red-600 dark:text-red-400">
+                {pdfError}
+              </div>
+            )}
+            {pdfStatus === "ready" && pdfName && (
+              <div className="text-sm text-black/60 dark:text-white/60">
+                Loaded: {pdfName} · ~{pdfTokenCount.toLocaleString()} tokens
+                {isPdfTruncated && " (truncated to ~10k tokens)"}
+              </div>
+            )}
+            {isSummarizing && (
+              <div className="text-sm text-black/60 dark:text-white/60">
+                Generating summary...
+              </div>
+            )}
+            {pdfSummaryError && (
+              <div className="text-sm text-red-600 dark:text-red-400">
+                {pdfSummaryError}
+              </div>
+            )}
+            {pdfSummary && (
+              <div className="rounded border border-black/10 bg-white p-3 text-sm text-black dark:border-white/10 dark:bg-neutral-800 dark:text-white">
+                <div className="mb-2 font-semibold">PDF Summary</div>
+                <div className="whitespace-pre-wrap">{pdfSummary}</div>
+              </div>
+            )}
+          </div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Allow users to upload a PDF to the local-inference demo and automatically produce a concise summary separate from the chat flow.
- Avoid the previous CDN dynamic-import approach and use the installed `pdfjs-dist` bundle with a configured worker to simplify parsing.
- Keep the original default chat prompt (`What color is the sun?`) and ensure PDF summarization does not interfere with regular chat inference.
- Provide user feedback about PDF loading, token estimates, truncation, and summarization status.

### Description
- Added `pdfjs-dist` usage and worker configuration via `GlobalWorkerOptions.workerSrc` and imported `pdfjs-dist/build/pdf.worker.min.js?url` to set the worker URL.
- Implemented PDF upload handling with text extraction, truncation to `MAX_PDF_TOKENS` (~10k tokens via `MAX_PDF_CHARS`), token estimation, and error states in `src/content/projects/local-inference/LocalInference.tsx`.
- Added automatic summary generation that calls the model via `engine.chat.completions.create` when a PDF is ready, storing results in `pdfSummary` and exposing UI state (`pdfStatus`, `isSummarizing`, `pdfSummaryError`).
- Restored the default prompt (`What color is the sun?`), moved the PDF upload UI below the chat response, disabled relevant controls while summarizing, and added `pdfjs-dist` to `package.json` dependencies.

### Testing
- Ran `npm install`, which failed due to registry permission (`403` accessing `pdfjs-dist`) so dependencies were not installed (failed).
- Ran `npm run build`, which failed because `astro` is not available in the execution environment so the site could not be built here (failed).
- No automated unit tests were added or executed as part of this change (not applicable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694da07af7e0832097075d2743365927)