### PR TITLE
Update back links to homepage (label -> "Back home")

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -30,7 +30,7 @@ const { Content, headings } = await post.render();
 <Layout title={post.data.title}>
   <Container>
     <div class="animate">
-      <BackToPrevious href="/blog">Back to blog</BackToPrevious>
+      <BackToPrevious href="/">Back home</BackToPrevious>
     </div>
     <div class="my-10">
       <h1 class="animate text-3xl font-semibold text-black dark:text-white">

--- a/src/pages/projects/[...slug].astro
+++ b/src/pages/projects/[...slug].astro
@@ -25,7 +25,7 @@ const { Content, headings } = await project.render();
 <Layout title={project.data.title}>
   <Container>
     <div class="animate">
-      <BackToPrevious href="/projects">Back to projects</BackToPrevious>
+      <BackToPrevious href="/">Back home</BackToPrevious>
     </div>
     <div class="my-10 space-y-1">
       <h1 class="animate text-3xl font-semibold text-black dark:text-white">


### PR DESCRIPTION
### Motivation

- Unify and simplify the back navigation on post and project detail pages by replacing context-specific labels with a single, clear destination.
- Ensure the back button consistently returns users to the site homepage rather than section index pages.

### Description

- Updated `src/pages/blog/[...slug].astro` to change the `BackToPrevious` usage from `href="/blog"` with label "Back to blog" to `href="/"` with label "Back home".
- Updated `src/pages/projects/[...slug].astro` to change the `BackToPrevious` usage from `href="/projects"` with label "Back to projects" to `href="/"` with label "Back home".
- The `BackToPrevious.astro` component itself was left unchanged and is still used to render the button UI.

### Testing

- Ran `npm install`, which failed due to a network error when downloading `onnxruntime-node` (install did not complete).
- Ran `npm run build`, which failed because `astro` was not available (dependencies not installed).
- Verified repository changes with `git status` and committed the updates successfully.
- Confirmed the updated files are `src/pages/blog/[...slug].astro` and `src/pages/projects/[...slug].astro`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f62415b908320931b12f0018fb783)