### PR TITLE
Revise homepage bio with expanded career narrative and anecdotes

### DIFF
--- a/src/content/home.mdx
+++ b/src/content/home.mdx
@@ -6,8 +6,13 @@ import HoverAvatar from "@components/HoverAvatar";
 
 I'm currently at xAI, working to advance state-of-the-art AI systems.
 
-I've spent time in both the Computer Vision and Natural Language Processing domains, most recently as the Head of AI Engineering at Harvey.
-Before that, I helped build and ship Full Self Driving on the Tesla Autopilot team.
+My career has bounced across both the Computer Vision and Natural Language Processing worlds: DeepScale (acquired by Tesla), Tesla Autopilot, Twitter/X during the acquisition transition, Harvey, and now back at xAI.
+
+I like building at moments of high leverage — from shipping Full Self Driving at Tesla to helping during the Twitter/X transition, then returning to xAI (later acquired by SpaceX).
+
+In short: I've had a front-row seat to a lot of M&A across Elon-led companies — intense, educational, and honestly pretty fun.
+
+At one point, Business Insider even mentioned me in coverage of the Twitter transition — still one of the more surreal moments of my career.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Make the homepage bio more informative and personal by expanding the short career summary into a clearer timeline of roles and organizations. 
- Surface notable experiences and context (M&A moments and press mentions) to better communicate background and perspective.

### Description
- Replaced the prior two-line summary with several sentences that list past roles and organizations including `DeepScale` (acquired by Tesla), `Tesla Autopilot`, `Twitter/X` during the acquisition transition, `Harvey`, and `xAI`.
- Added narrative framing about building at high-leverage moments, a note about M&A exposure across Elon-led companies, and a mention that `xAI` was later acquired by `SpaceX`, plus a Business Insider mention anecdote.

### Testing
- Built the site locally with `yarn build` to validate the MDX change and the build completed successfully. 
- Ran the local dev server with `yarn dev` to verify the updated `src/content/home.mdx` renders correctly and there were no runtime errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c46e9dc05483208114cca40ee08ac5)